### PR TITLE
Fix submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "picoros"]
 	path = picoros
-	url = git@github.com:Pico-ROS/Pico-ROS-software.git
+	url = https://github.com/Pico-ROS/Pico-ROS-software.git


### PR DESCRIPTION
With the current setup, nobody but repo maintainers can actually clone the submodule. This PR fixes it.

If you need to push in the submodule, cd into it and

    git config remote.origin.pushurl git@github.com:Pico-ROS/Pico-ROS-software.git
