### PR TITLE
Fix the issue where the picoros submodule could not be pulled

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "picoros"]
 	path = picoros
-	url = git@github.com:Pico-ROS/Pico-ROS-software.git
+	url = https://github.com/Pico-ROS/Pico-ROS-software.git

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,6 @@ Use for quick integration into ESP-IDF projects.
 1. Inside ESP-IDF project root:
 ```sh
 # Pull this repository
-git submodule add git@github.com:Pico-ROS/picoros-espidf-component.git components/picoros
 git submodule update --init --recursive
 # Copy example ROS types:
 cp components/picoros/picoros/examples/example_types.h main/my_ros_types.h

--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,7 @@ Use for quick integration into ESP-IDF projects.
 1. Inside ESP-IDF project root:
 ```sh
 # Pull this repository
-# git clone https://github.com/Pico-ROS/picoros-espidf-component components/picoros
-git clone https://github.com/fish1sheep/picoros-espidf-component.git components/picoros
+git clone https://github.com/Pico-ROS/picoros-espidf-component components/picoros
 cd components/picoros && git submodule update --init --recursive
 # Copy example ROS types:
 cp components/picoros/picoros/examples/example_types.h main/my_ros_types.h

--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,8 @@ Use for quick integration into ESP-IDF projects.
 1. Inside ESP-IDF project root:
 ```sh
 # Pull this repository
-git clone https://github.com/Pico-ROS/picoros-espidf-component components/picoros
-# git clone https://github.com/fish1sheep/picoros-espidf-component.git components/picoros
+# git clone https://github.com/Pico-ROS/picoros-espidf-component components/picoros
+git clone https://github.com/fish1sheep/picoros-espidf-component.git components/picoros
 cd components/picoros && git submodule update --init --recursive
 # Copy example ROS types:
 cp components/picoros/picoros/examples/example_types.h main/my_ros_types.h

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,8 @@ Use for quick integration into ESP-IDF projects.
 1. Inside ESP-IDF project root:
 ```sh
 # Pull this repository
-git submodule update --init --recursive
+git clone https://github.com/Pico-ROS/picoros-espidf-component components/picoros
+cd components/picoros && git submodule update --init --recursive
 # Copy example ROS types:
 cp components/picoros/picoros/examples/example_types.h main/my_ros_types.h
 ```

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ Use for quick integration into ESP-IDF projects.
 ```sh
 # Pull this repository
 git clone https://github.com/Pico-ROS/picoros-espidf-component components/picoros
+# git clone https://github.com/fish1sheep/picoros-espidf-component.git components/picoros
 cd components/picoros && git submodule update --init --recursive
 # Copy example ROS types:
 cp components/picoros/picoros/examples/example_types.h main/my_ros_types.h


### PR DESCRIPTION
Running `git submodule update --init --recursive` in the official repository fails to pull the submodule.
I refactored the submodule fetching code, and then running `git submodule update --init --recursive` again in the repository resolves the issue.